### PR TITLE
Fix GM mob spawning

### DIFF
--- a/server/src/client/client.py
+++ b/server/src/client/client.py
@@ -326,7 +326,7 @@ class Client(Mailbox):
             x = read_uint(data, 5) / 10.0
             y = read_short(data, 9) / 10.0
             # self.logger.info('Client %s wants to spawn %s at (%s,%s)' % (self, mob_type, x, y))
-            self.world.send_mail_message(mail_header.MSG_ADD_MOB, (mob_type, x, y, self.get_mob_spawn(), self.world))
+            self.world.send_mail_message(mail_header.MSG_ADD_MOB, (mob_type, x, y, self.get_mob_spawn()))
 
         elif header == packet.MSG_LEVEL_UP:
             new_level = read_byte(data, 2)

--- a/server/src/world/world.py
+++ b/server/src/world/world.py
@@ -195,7 +195,7 @@ class World(Mailbox):
 
             elif header == mail_header.MSG_ADD_MOB:
                 mob_id = self._generate_mob_id()
-                mob_type, mob_x, mob_y, mob_spawner, world = payload
+                mob_type, mob_x, mob_y, mob_spawner = payload
                 new_mob = Mob(mob_id, mob_type, mob_x, mob_y, mob_spawner, self)
                 if mob_spawner:
                     mob_spawner._add_mob(new_mob)

--- a/server/src/world/world.py
+++ b/server/src/world/world.py
@@ -195,7 +195,7 @@ class World(Mailbox):
 
             elif header == mail_header.MSG_ADD_MOB:
                 mob_id = self._generate_mob_id()
-                mob_type, mob_x, mob_y, mob_spawner = payload
+                mob_type, mob_x, mob_y, mob_spawner, world = payload
                 new_mob = Mob(mob_id, mob_type, mob_x, mob_y, mob_spawner, self)
                 if mob_spawner:
                     mob_spawner._add_mob(new_mob)


### PR DESCRIPTION
The payload tuple expects 5 values. It errors if there's only 4 variables. So mob spawning doesn't work if done through the `MSG_SPAWN_MOB` packet.

I'm not sure if there's an idiomatic way to ignore a value in python so I just gave it the name `world`.