### PR TITLE
Add configurable follow radius multiplier

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -6,7 +6,7 @@
     "mob_spawn_count_max_multiplier": 1.0,
     "mob_spawn_chance_boss_multiplier": 2.0,
     "mob_spawn_chance_bunny_multiplier": 1.0,
-    "mob_follow_radius_multiplier": 2.0,
+    "mob_follow_radius_multiplier": 1.0,
     "player_damage_multiplier": 2.0,
     "player_start_gold": 500,
 

--- a/server/config.json
+++ b/server/config.json
@@ -6,6 +6,7 @@
     "mob_spawn_count_max_multiplier": 1.0,
     "mob_spawn_chance_boss_multiplier": 2.0,
     "mob_spawn_chance_bunny_multiplier": 1.0,
+    "mob_follow_radius_multiplier": 2.0,
     "player_damage_multiplier": 2.0,
     "player_start_gold": 500,
 

--- a/server/src/config/__init__.py
+++ b/server/src/config/__init__.py
@@ -18,6 +18,7 @@ MOB_SPAWN_RATE_MULTIPLIER = config_json['mob_spawn_rate_multiplier']
 MOB_SPAWN_COUNT_MAX_MULTIPLIER = config_json['mob_spawn_count_max_multiplier']
 MOB_SPAWN_CHANCE_BOSS_MULTIPLIER = config_json['mob_spawn_chance_boss_multiplier']
 MOB_SPAWN_CHANCE_BUNNY_MULTIPLIER = config_json['mob_spawn_chance_bunny_multiplier']
+MOB_FOLLOW_RADIUS_MULTIPLIER = config_json['mob_follow_radius_multiplier']
 PLAYER_DAMAGE_MULTIPLIER = config_json['player_damage_multiplier']
 PLAYER_START_GOLD = config_json['player_start_gold']
 

--- a/server/src/world/mob.py
+++ b/server/src/world/mob.py
@@ -69,11 +69,11 @@ class Mob():
             self.image_index = randint(0, self.sprite['frames'] - 1)
             self.direction = 1
 
-        # the original game didn't multiply the search radius by 1.5, but I find it makes the mobs feel much more lively
+        # the original game didn't multiply the search radius, but I find a larger radius makes the mobs feel much more lively
         self.client_aggrov = None
         self.follow_radius = int(round(self.mob_dat['follow_radius']))
-        self.follow_radius_2x = int(round(self.mob_dat['follow_radius'] * 2.0))
-        self.walk_section_search_radius = ceildiv(self.follow_radius_2x, config.WORLD_SECTION_WIDTH)
+        self.follow_radius_multiplier = int(round(self.mob_dat['follow_radius'] * config.MOB_FOLLOW_RADIUS_MULTIPLIER))
+        self.walk_section_search_radius = ceildiv(self.follow_radius_multiplier, config.WORLD_SECTION_WIDTH)
 
         self.dmg_bbox = None
         self.atk_search_radius = ceildiv(self.follow_radius, config.WORLD_SECTION_WIDTH)
@@ -168,7 +168,7 @@ class Mob():
                 # mobs are run on the world thread, so we can call
                 # world._find_player_nearest without issue
                 client_aggrov = self.world._find_player_nearest(self.get_bbox().hcenter(), section_radius=self.walk_section_search_radius)
-                if client_aggrov is not None and dist(self.x, self.y, client_aggrov.x, client_aggrov.y) <= self.follow_radius_2x:
+                if client_aggrov is not None and dist(self.x, self.y, client_aggrov.x, client_aggrov.y) <= self.follow_radius_multiplier:
                     self.client_aggrov = client_aggrov
                     if self.client_aggrov.get_bbox().hcenter() <= self.get_bbox().hcenter():
                         self._set_sprite(SPRITE_INDEX_WALK)


### PR DESCRIPTION
This adds the `mob_follow_radius_multiplier` config setting allowing the local-so follow radius multiplier to be changed.

Personally, I'm not a fan of the increased range. It's not possible to tell when most mobs have stopped following the player, and bunnies are impossible to find without sufficient agility, multiple players, or seeing one just as it spawns.

The comment about why this was changed might need to be moved. I tried to change it to make more sense with this new context.